### PR TITLE
Implement switching model types on startup

### DIFF
--- a/objects_counter/api/default/views.py
+++ b/objects_counter/api/default/views.py
@@ -18,7 +18,7 @@ from image_segmentation.object_classification.feature_extraction import CosineSi
 from image_segmentation.object_detection.object_segmentation import ObjectSegmentation
 from objects_counter.api.default.models import points_model
 from objects_counter.api.utils import authentication_optional
-from objects_counter.consts import SAM_CHECKPOINT
+from objects_counter.consts import SAM_CHECKPOINT, SAM_MODEL_TYPE
 from objects_counter.db.dataops.image import insert_image, update_background_points, get_image_by_id
 from objects_counter.db.dataops.result import insert_result
 from objects_counter.db.models import User
@@ -26,7 +26,7 @@ from objects_counter.db.models import User
 api = Namespace('default', description='Default namespace')
 process_parser = api.parser()
 process_parser.add_argument('image', type=FileStorage, location='files')
-sam = ObjectSegmentation(SAM_CHECKPOINT)
+sam = ObjectSegmentation(SAM_CHECKPOINT, model_type=SAM_MODEL_TYPE)
 similarity_model = CosineSimilarity()
 object_grouper = ObjectClassifier(sam, similarity_model)
 

--- a/objects_counter/consts.py
+++ b/objects_counter/consts.py
@@ -5,4 +5,5 @@ UPLOAD_FOLDER = 'uploads'
 DB_NAME = 'object_counter.sqlite'
 MAX_DB_STRING_LENGTH = 255
 SAM_CHECKPOINT = os.environ.get('SAM_CHECKPOINT')
+SAM_MODEL_TYPE = os.environ.get('SAM_MODEL_TYPE', 'vit_h')
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')

--- a/start.bat
+++ b/start.bat
@@ -7,6 +7,7 @@ IF "%SAM_CHECKPOINT%"=="" (
     ECHO "SAM_CHECKPOINT not specified"
     EXIT /B 1
 )
+IF NOT "%~2"=="" SET "SAM_MODEL_TYPE=%~2"
 cd objects_counter
 flask db init
 flask db upgrade

--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,10 @@ then
 else
     echo "SAM_CHECKPOINT is set to $SAM_CHECKPOINT"
 fi
+if [ -n "$2" ]
+then
+    export SAM_MODEL_TYPE=$2
+fi
 cd objects_counter || exit
 flask db init
 flask db upgrade


### PR DESCRIPTION
Added a function to switch to another model type on startup. Previously, the default was "vit_h", the most powerful SAM model type. This posed an issue with low performance on my machine after expanding our app.

Currently, the default model is still "vit_h", but you can specify a model type in start scripts, after the checkpoint. If no type is specified, "vit_h" is assumed.

Possible values are "vit_h", "vit_l" and "vit_b". A correct checkpoint is still required.